### PR TITLE
Update image in k8s/deployment.yaml

### DIFF
--- a/todoapp/k8s/deployment.yaml
+++ b/todoapp/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: todoapp
-          image: public.ecr.aws/j7f8d3t2/todoapp@sha256:6224c86267a798e98de9bfe5f98eaa3f55a1adfcd6757acc59e593f2ccdb37f2
+          image: public.ecr.aws/j7f8d3t2/todoapp
           imagePullPolicy: Always
           ports:
             - containerPort: 80


### PR DESCRIPTION
## Changes

Kustomize has a [bug](https://github.com/GoogleContainerTools/skaffold/issues/4771#issuecomment-792614503) when you replace a digest with both tag and digest.

Eg:
```shell
$ cat kustomization.yaml
resources: ["deployment.yaml", "service.yaml"]

images:
  - name: "public.ecr.aws/j7f8d3t2/todoapp@sha256:6224c86267a798e98de9bfe5f98eaa3f55a1adfcd6757acc59e593f2ccdb37f2"
    newName: "localhost:5000/kind:test-kind-azkestizysbx@sha256:cb8d92518b876a3fe15a23f7c071290dfbad50283ad976f3f5b93e9f20cefee6"

$ kustomize build . | grep image
      - image: localhost:5000/kind:test-kind-azkestizysbx@sha256:cb8d92518b876a3fe15a23f7c071290dfbad50283ad976f3f5b93e9f20cefee6@sha256:6224c86267a798e98de9bfe5f98eaa3f55a1adfcd6757acc59e593f2ccdb37f2
        imagePullPolicy: Always
```

As you see, digest has been concat instead of replace it..
Si I've remote the digest from `deployment.yaml` to avoid that bug