### PR TITLE
Fix implicit role of list issue

### DIFF
--- a/todoapp/src/App.js
+++ b/todoapp/src/App.js
@@ -108,7 +108,6 @@ function App(props) {
         {headingText}
       </h2>
       <ul
-        role="list"
         className="todo-list stack-large stack-exception"
         aria-labelledby="list-heading"
       >


### PR DESCRIPTION
One of our user encountered breaking CIs with azure because of :
```
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.
Failed to compile.

./src/App.js
  Line 110:7:  The element ul has an implicit role of list. Defining this explicitly is redundant and should be avoided  jsx-a11y/no-redundant-roles
  ```
The CI broke because of this output.

After checking with @slumbering, we can safely remove this role, as it's an example app

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>