### PR TITLE
Change default todoapp port to 8020

### DIFF
--- a/todoapp/dev.cue
+++ b/todoapp/dev.cue
@@ -9,7 +9,7 @@ import (
 dagger.#Plan & {
 	inputs: {
 		directories: app: path: "./"
-		params: web: hostPort:  string | *"8080"
+		params: web: hostPort:  string | *"8020"
 	}
 	actions: {
 		build: yarn.#Build & {


### PR DESCRIPTION
The chances of 8080 being in use and the command failing due to this port clash are higher than if we pick a less common port by default.