### PR TITLE
Added deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,100 @@
-# Dagger Examples
+# DEPRECATION NOTICE
 
-If you'd like to see a new example, please open an issue.
+This repository is deprecated and will be removed on 1 Dec 2023. Dagger SDK examples in this repository have been migrated to the [primary Dagger repository](https://github.com/dagger/dagger) and work will continue in the new locations below:
+
+- [Go SDK examples](https://github.com/dagger/dagger/tree/main/sdk/go/examples)
+- [Node.js SDK examples](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples)
+- [Python SDK examples](https://github.com/dagger/dagger/tree/main/sdk/python/examples)
+
+# Dagger Examples
 
 ## Core Concepts
 
 ### Mounting source files to a container
 
-- [Go](./go/db-service/main.go#L37)
-- [NodeJS](./nodejs/db-service/build.js#L19)
-- [Python](./python/db-service/pipeline.py#L28)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/db-service/main.go#L37)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/db-service/build.js#L19)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/db-service/pipeline.py#L28)
 
 ### Multi-stage build
 
-- [Go](./go/multistage/main.go#L31)
-- [NodeJS](./nodejs/multistage/build.js#L14)
-- [Python](./python/multistage/pipeline.py#L19)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/multistage/main.go#L31)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/multistage/build.js#L14)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/multistage/pipeline.py#L19)
 
 ### Multi-platform build
 
-- [Go](./go/multiplatform/main.go#L30)
-- [NodeJS](./nodejs/multiplatform/build.js#L16)
-- [Python](./python/multiplatform/pipeline.py#L19)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/multiplatform/main.go#L30)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/multiplatform/build.js#L16)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/multiplatform/pipeline.py#L19)
 
 ### Cache mounts
 
-- [Go](./go/multiplatform/main.go#L34)
-- [NodeJS](./nodejs/multiplatform/build.js#L20)
-- [Python](./python/multiplatform/pipeline.py#L23)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/multiplatform/main.go#L34)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/multiplatform/build.js#L20)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/multiplatform/pipeline.py#L23)
 
 ### Concurrency
 
 Note: While the DAG is constructed serially, the engine will execute the full DAG when the build artifacts directory is exported. Since each platform's build doesn't depend on the others, the engine will execute each build concurrently.
 
-- [Go](./go/multiplatform/main.go#L29)
-- [NodeJS](./nodejs/multiplatform/build.js#L15)
-- [Python](./python/multiplatform/pipeline.py#L17)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/multiplatform/main.go#L29)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/multiplatform/build.js#L15)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/multiplatform/pipeline.py#L17)
 
 ### Container publishing
 
-- [Go](./go/multistage/main.go#L41)
-- [NodeJS](./nodejs/multistage/build.js#L23)
-- [Python](./python/multistage/pipeline.py#L30)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/multistage/main.go#L41)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/multistage/build.js#L23)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/multistage/pipeline.py#L30)
 
 ### Secrets
 
-- [Go](./go/secrets/main.go#L21)
-- [NodeJS](./nodejs/secrets/ci.js#L6)
-- [Python](./python/secrets/pipeline.py#L9)
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/secrets/main.go#L21)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/secrets/ci.js#L6)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/secrets/pipeline.py#L9)
 
 ### Services
 
-- [Go](./go/db-service/main.go#L22)
-- [NodeJS](./nodejs/db-service/build.js#L6)
-- [Python](./python/db-service/pipeline.py#L10)
-
-### Testing your pipelines
-
-- [Go]() TODO
-- [NodeJS]() TODO
-- [Python]() TODO
+- [Go](https://github.com/dagger/dagger/blob/main/sdk/go/examples/db-service/main.go#L22)
+- [NodeJS](https://github.com/dagger/dagger/blob/main/sdk/nodejs/examples/db-service/build.js#L6)
+- [Python](https://github.com/dagger/dagger/blob/main/sdk/python/examples/db-service/pipeline.py#L10)
 
 ## By Language
 
 ### Go
 
-- [multiarch build](./go/multiarch-build/)
-- [npm build](./go/npm-build/)
-- [yarn build](./go/yarn-build/)
-- [gradle build](./go/gradle-build/)
-- [services](./go/db-service/)
-- [secrets](./go/secrets/)
-- [multiplatform](./go/multiplatform/)
-- [multistage](./go/multistage/)
-- [replace dockerfile](./go/replace-dockerfile/)
-- [aws cdk](./go/aws-cdk/)
+- [multiarch build](https://github.com/dagger/dagger/tree/main/sdk/go/examples/multiarch-build/)
+- [npm build](https://github.com/dagger/dagger/tree/main/sdk/go/examples/npm-build/)
+- [yarn build](https://github.com/dagger/dagger/tree/main/sdk/go/examples/yarn-build/)
+- [gradle build](https://github.com/dagger/dagger/tree/main/sdk/go/examples/gradle-build/)
+- [services](https://github.com/dagger/dagger/tree/main/sdk/go/examples/db-service/)
+- [secrets](https://github.com/dagger/dagger/tree/main/sdk/go/examples/secrets/)
+- [multiplatform](https://github.com/dagger/dagger/tree/main/sdk/go/examples/multiplatform/)
+- [multistage](https://github.com/dagger/dagger/tree/main/sdk/go/examples/multistage/)
+- [replace dockerfile](https://github.com/dagger/dagger/tree/main/sdk/go/examples/replace-dockerfile/)
+- [aws cdk](https://github.com/dagger/dagger/tree/main/sdk/go/examples/aws-cdk/)
 
 ### Python
 
-- [basic example](./python/basic-example/)
-- [services](./python/db-service/)
-- [secrets](./python/secrets/)
-- [multiplatform](./python/multiplatform/)
-- [multistage](./python/multistage/)
+- [basic example](https://github.com/dagger/dagger/tree/main/sdk/python/examples/basic-example/)
+- [services](https://github.com/dagger/dagger/tree/main/sdk/python/examples/db-service/)
+- [secrets](https://github.com/dagger/dagger/tree/main/sdk/python/examples/secrets/)
+- [multiplatform](https://github.com/dagger/dagger/tree/main/sdk/python/examples/multiplatform/)
+- [multistage](https://github.com/dagger/dagger/tree/main/sdk/python/examples/multistage/)
 
 ### Node.js (Typescript/Javascript)
 
-- [react build](./nodejs/react-build/)
-- [services](./nodejs/db-service/)
-- [secrets](./nodejs/secrets/)
-- [multiplatform](./nodejs/multiplatform/)
-- [multistage](./nodejs/multistage/)
-- [Pulumi](./nodejs/pulumi/)
+- [react build](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/react-build/)
+- [services](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/db-service/)
+- [secrets](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/secrets/)
+- [multiplatform](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/multiplatform/)
+- [multistage](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/multistage/)
+- [Pulumi](https://github.com/dagger/dagger/tree/main/sdk/nodejs/examples/pulumi/)
 
 ### Bash with Dagger CLI and GraphQL
 
-- [git build](./bash/git-build/)
+- [git build](https://github.com/dagger/dagger/tree/main/cmd/examples/git-build/)
 
 ### GraphQL queries
 


### PR DESCRIPTION
This commit adds a deprecation notice to the repository and updates links to point to the new location of the Dagger examples.
See also: https://github.com/dagger/dagger/pull/5677